### PR TITLE
Modify: APSS gain value of FANS

### DIFF
--- a/mowgli.xml
+++ b/mowgli.xml
@@ -62859,7 +62859,7 @@
 	</attribute>
 	<attribute>
 		<id>ADC_CHANNEL_GAIN</id>
-		<default>10741</default>
+		<default>15408</default>
 	</attribute>
 	<attribute>
 		<id>ADC_CHANNEL_GROUND</id>


### PR DESCRIPTION
Due to design changes, change APSS gain value of FANS from 10741 to 15408.

Signed-off-by: LuluTHSu <Lulu_Su@wistron.com>